### PR TITLE
Carry-forward TFM-specific features

### DIFF
--- a/src/Interval.cs
+++ b/src/Interval.cs
@@ -26,7 +26,7 @@ namespace ClockQuantization
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             internal static ref readonly SnapshotTracker WithNextSerialPosition(ref SnapshotTracker tracker)
             {
-#if NET5_0
+#if NET5_0 || NET5_0_OR_GREATER
                 Interlocked.Increment(ref tracker.SerialPosition);
 #else
                 Interlocked.Add(ref Unsafe.As<uint, int>(ref tracker.SerialPosition), 1);
@@ -78,7 +78,7 @@ namespace ClockQuantization
         internal Interval Seal()
         {
             // Prevent 'Exact' positions post initialization of the Interval; ensure SerialPosition > 0
-#if NET5_0
+#if NET5_0 || NET5_0_OR_GREATER
             Interlocked.CompareExchange(ref _tracker.SerialPosition, 1u, 0u);
 #else
             Interlocked.CompareExchange(ref Unsafe.As<uint, int>(ref _tracker.SerialPosition), 1, 0);

--- a/src/LazyClockOffsetSerialPosition.cs
+++ b/src/LazyClockOffsetSerialPosition.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using System.Diagnostics;
+#if NETSTANDARD2_1 || NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0 || NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Runtime.CompilerServices;
 
 namespace ClockQuantization
@@ -32,8 +35,11 @@ namespace ClockQuantization
     {
         private static class ThrowHelper
         {
+#if NETSTANDARD2_1 || NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0 || NET5_0_OR_GREATER
+            [DoesNotReturn]
+#endif
             [MethodImpl(MethodImplOptions.NoInlining)]
-            public static InvalidOperationException CreateInvalidOperationException() => new InvalidOperationException();
+            internal static T ThrowInvalidOperationException<T>() => throw new InvalidOperationException();
         }
 
         private readonly struct Snapshot
@@ -54,12 +60,12 @@ namespace ClockQuantization
         /// <value>Returns the offset assigned to the current value.</value>
         /// <exception cref="InvalidOperationException">When <see cref="HasValue"/> is <see langword="false"/>.</exception>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        public readonly long ClockOffset { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => HasValue ? _snapshot.ClockOffset : throw ThrowHelper.CreateInvalidOperationException(); }
+        public readonly long ClockOffset { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => HasValue ? _snapshot.ClockOffset : ThrowHelper.ThrowInvalidOperationException<long>(); }
 
         /// <value>Returns the serial position assigned to the current value.</value>
         /// <exception cref="InvalidOperationException">When <see cref="HasValue"/> is <see langword="false"/>.</exception>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        public readonly uint SerialPosition { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => HasValue ? _snapshot.SerialPosition : throw ThrowHelper.CreateInvalidOperationException(); }
+        public readonly uint SerialPosition { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => HasValue ? _snapshot.SerialPosition : ThrowHelper.ThrowInvalidOperationException<uint>(); }
 
         /// <value>Returns <see langword="true"/> if a value is assigned, <see langword="false"/> otherwise.</value>
         public readonly bool HasValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _snapshot.SerialPosition > 0u; }

--- a/tests/ClockQuantization.Tests/assets/SystemClockTemporalContext.cs
+++ b/tests/ClockQuantization.Tests/assets/SystemClockTemporalContext.cs
@@ -92,7 +92,7 @@ namespace ClockQuantization.Tests.Assets
             ProvidesMetronome = (_metronomeOptions = metronomeOptions) is not null;
             IsMetronomeRunning = ProvidesMetronome && ApplyMetronomeOptions(metronomeOptions!, Metronome_Ticked, out _metronome);
 
-#if NET5_0
+#if NET5_0 || NET5_0_OR_GREATER
             var utcNow = DateTimeOffset.UtcNow;
             var milliSecondsSinceGenesis = Environment.TickCount64; // The number of milliseconds elapsed since the system started.
 
@@ -100,7 +100,7 @@ namespace ClockQuantization.Tests.Assets
 #endif
         }
 
-#if NET5_0
+#if NET5_0 || NET5_0_OR_GREATER
         public readonly DateTimeOffset UtcGenesis;
 #endif
 
@@ -109,7 +109,7 @@ namespace ClockQuantization.Tests.Assets
         public long UtcNowClockOffset
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if NET5_0
+#if NET5_0 || NET5_0_OR_GREATER
             get => HasExternalClock ? Environment.TickCount64 : _manual!.UtcNowClockOffset;
 #else
             get => HasExternalClock ? UtcNow.UtcTicks : _manual!.UtcNowClockOffset;
@@ -125,7 +125,7 @@ namespace ClockQuantization.Tests.Assets
                 return _manual!.ClockOffsetToUtcDateTimeOffset(offset);
             }
 
-#if NET5_0
+#if NET5_0 || NET5_0_OR_GREATER
             return UtcGenesis + TimeSpan.FromMilliseconds(offset);
 #else
             return new DateTimeOffset(offset, TimeSpan.Zero);
@@ -140,7 +140,7 @@ namespace ClockQuantization.Tests.Assets
                 return _manual!.DateTimeOffsetToClockOffset(offset);
             }
 
-#if NET5_0
+#if NET5_0 || NET5_0_OR_GREATER
             return (long) (offset.UtcDateTime - UtcGenesis).TotalMilliseconds;
 #else
             return offset.UtcTicks;
@@ -156,7 +156,7 @@ namespace ClockQuantization.Tests.Assets
                     return _manual!.ClockOffsetUnitsPerMillisecond;
                 }
 
-#if NET5_0
+#if NET5_0 || NET5_0_OR_GREATER
                 return 1;
 #else
                 return TimeSpan.TicksPerMillisecond;


### PR DESCRIPTION
Closes #2 
Closes #3 

Note that is not enough to replace `#if NET5_0` with `#if NET5_0_OR_GREATER`. Instead, `#if NET5_0 || NET5_0_OR_GREATER` must be used.